### PR TITLE
ci: mirror refs to Forgejo backup on every push

### DIFF
--- a/.github/workflows/mirror-to-forgejo.yml
+++ b/.github/workflows/mirror-to-forgejo.yml
@@ -1,0 +1,25 @@
+name: Mirror to Forgejo
+
+on:
+  push:
+
+jobs:
+  mirror:
+    name: Push refs to Forgejo backup
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Mirror refs to Forgejo
+        run: |
+          git remote add forgejo https://github.mindstacklab.ai/tiezbro/paseo-agy-acp.git
+          git -c http.extraheader="Authorization: token ${FORGEJO_TOKEN}" \
+              -c http.version=HTTP/1.1 \
+              push --mirror forgejo
+        env:
+          FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
+          GIT_TERMINAL_PROMPT: "0"


### PR DESCRIPTION
On every push (any branch/tag), mirror all refs to the Forgejo backup at github.mindstacklab.ai/tiezbro/paseo-agy-acp via `git push --mirror`.

- Uses the `FORGEJO_TOKEN` repo secret (write:repository) over an HTTP extra header so the token never appears in the remote URL in public logs.
- This replaces the old Forgejo→GitHub push mirror (already removed on the Forgejo side) to stop the push/pull loop and make GitHub the single source of truth.

## Verify after merge
Merge this, then watch the Actions run: it should push the full ref set to Forgejo. Check https://github.mindstacklab.ai/tiezbro/paseo-agy-acp — default branch commit should match GitHub main.