### PR TITLE
feat: augment availableCommands with local skills for ACP slash command hints

### DIFF
--- a/ACP Connector/official-kernel/context.ts
+++ b/ACP Connector/official-kernel/context.ts
@@ -48,3 +48,11 @@ export function extractSessionId(params: unknown): string | undefined {
       ? params.session_id
       : undefined;
 }
+
+export function extractCwd(params: unknown): string | undefined {
+  if (!isRecord(params)) return undefined;
+  return typeof params.cwd === "string" && params.cwd.trim().length > 0
+    ? params.cwd.trim()
+    : undefined;
+}
+

--- a/ACP Connector/official-kernel/proxy.ts
+++ b/ACP Connector/official-kernel/proxy.ts
@@ -2,7 +2,7 @@ import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import type { Readable, Writable } from "node:stream";
 import { TurnClaim } from "../acp/session/turn-scheduler.js";
 import { createOfficialAdmission, issueAdmittedOfficialPromptWrite } from "./admission-fence.js";
-import { extractPromptText, extractSessionId, injectPaseoContext } from "./context.js";
+import { extractCwd, extractPromptText, extractSessionId, injectPaseoContext } from "./context.js";
 import { blankTurnError, sessionUpdateShowsVisibleOutput, shouldRejectBlankTurn } from "./errors.js";
 import { overlayProductIdentity } from "./identity.js";
 import {
@@ -22,6 +22,8 @@ import { augmentAvailableCommands, type AvailableCommand } from "./skill-command
 
 const INITIALIZE_METHOD = "initialize";
 const SESSION_NEW_METHOD = "session/new";
+const SESSION_LOAD_METHOD = "session/load";
+const SESSION_RESUME_METHOD = "session/resume";
 const SESSION_PROMPT_METHOD = "session/prompt";
 const SESSION_SET_MODE_METHOD = "session/set_mode";
 const SESSION_SET_CONFIG_METHOD = "session/set_config_option";
@@ -31,6 +33,7 @@ const SESSION_UPDATE_METHOD = "session/update";
 interface PendingClientRequest {
   method: string;
   sessionId?: string;
+  cwd?: string;
   sawVisibleOutput: boolean;
   resolve: (message: JsonRpcMessage) => void;
 }
@@ -50,6 +53,7 @@ export class OfficialKernelProxy {
   readonly #version: string;
   readonly #pending = new Map<JsonRpcId, PendingClientRequest>();
   readonly #claims = new Map<string, TurnClaim>();
+  readonly #sessionCwds = new Map<string, string>();
   readonly #env: NodeJS.ProcessEnv;
   readonly #admission;
   #closed = false;
@@ -128,6 +132,15 @@ export class OfficialKernelProxy {
     let params = request.params;
     if (request.method === SESSION_NEW_METHOD) {
       params = rewriteMcpServers(rewriteModeFields(params));
+    } else if (
+      request.method === SESSION_LOAD_METHOD ||
+      request.method === SESSION_RESUME_METHOD
+    ) {
+      const sessionId = extractSessionId(params);
+      const cwd = extractCwd(params);
+      if (sessionId && cwd) {
+        this.#sessionCwds.set(sessionId, cwd);
+      }
     } else if (request.method === SESSION_SET_MODE_METHOD || request.method === SESSION_SET_CONFIG_METHOD) {
       params = rewriteModeFields(params);
     } else if (request.method === SESSION_PROMPT_METHOD) {
@@ -189,6 +202,7 @@ export class OfficialKernelProxy {
       this.#pending.set(id, {
         method,
         sessionId: extractSessionId(params),
+        cwd: extractCwd(params),
         sawVisibleOutput: false,
         resolve
       });
@@ -220,7 +234,19 @@ export class OfficialKernelProxy {
         | undefined;
 
       if (params?.update?.sessionUpdate === "available_commands_update") {
-        const augmented = augmentAvailableCommands(params.update.availableCommands);
+        let cwd = sessionId ? this.#sessionCwds.get(sessionId) : undefined;
+        if (!cwd) {
+          for (const pending of this.#pending.values()) {
+            if (pending.cwd) {
+              cwd = pending.cwd;
+              if (sessionId) {
+                this.#sessionCwds.set(sessionId, cwd);
+              }
+              break;
+            }
+          }
+        }
+        const augmented = augmentAvailableCommands(params.update.availableCommands, cwd);
         message = {
           ...message,
           params: {
@@ -248,6 +274,16 @@ export class OfficialKernelProxy {
       if (pending.method === INITIALIZE_METHOD && isJsonRpcSuccess(message)) {
         outbound = { ...message, result: overlayProductIdentity(message.result, this.#version) };
       } else if (
+        (pending.method === SESSION_NEW_METHOD ||
+          pending.method === SESSION_LOAD_METHOD ||
+          pending.method === SESSION_RESUME_METHOD) &&
+        isJsonRpcSuccess(message)
+      ) {
+        const sessionId = extractSessionId(message.result) ?? pending.sessionId;
+        if (sessionId && pending.cwd) {
+          this.#sessionCwds.set(sessionId, pending.cwd);
+        }
+      } else if (
         pending.method === SESSION_PROMPT_METHOD &&
         isJsonRpcSuccess(message) &&
         shouldRejectBlankTurn(message.result, pending.sawVisibleOutput)
@@ -262,3 +298,4 @@ export class OfficialKernelProxy {
     this.#writeClient(message);
   }
 }
+

--- a/ACP Connector/official-kernel/proxy.ts
+++ b/ACP Connector/official-kernel/proxy.ts
@@ -18,6 +18,7 @@ import {
 import { rewriteMcpServers } from "./mcp-rewrite.js";
 import { rewriteModeFields } from "./mode-map.js";
 import { createNdjsonParser, encodeNdjson } from "./ndjson.js";
+import { augmentAvailableCommands, type AvailableCommand } from "./skill-commands.js";
 
 const INITIALIZE_METHOD = "initialize";
 const SESSION_NEW_METHOD = "session/new";
@@ -207,6 +208,31 @@ export class OfficialKernelProxy {
           }
         }
       }
+
+      const params = message.params as
+        | {
+            sessionId?: string;
+            update?: {
+              sessionUpdate?: string;
+              availableCommands?: AvailableCommand[];
+            };
+          }
+        | undefined;
+
+      if (params?.update?.sessionUpdate === "available_commands_update") {
+        const augmented = augmentAvailableCommands(params.update.availableCommands);
+        message = {
+          ...message,
+          params: {
+            ...params,
+            update: {
+              ...params.update,
+              availableCommands: augmented
+            }
+          }
+        };
+      }
+
       this.#writeClient(message);
       return;
     }

--- a/ACP Connector/official-kernel/proxy.ts
+++ b/ACP Connector/official-kernel/proxy.ts
@@ -56,6 +56,7 @@ export class OfficialKernelProxy {
   readonly #sessionCwds = new Map<string, string>();
   readonly #env: NodeJS.ProcessEnv;
   readonly #admission;
+  #sessionNewTail: Promise<void> = Promise.resolve();
   #closed = false;
 
   constructor(options: OfficialKernelProxyOptions) {
@@ -132,6 +133,8 @@ export class OfficialKernelProxy {
     let params = request.params;
     if (request.method === SESSION_NEW_METHOD) {
       params = rewriteMcpServers(rewriteModeFields(params));
+      await this.#forwardSessionNew(request, params);
+      return;
     } else if (
       request.method === SESSION_LOAD_METHOD ||
       request.method === SESSION_RESUME_METHOD
@@ -151,6 +154,24 @@ export class OfficialKernelProxy {
 
     this.#track(request.id, request.method, params);
     this.#writeChild({ ...request, jsonrpc: "2.0", params });
+  }
+
+  // Early session updates have no request id, so keep only one unbound cwd in flight.
+  async #forwardSessionNew(request: JsonRpcRequest, params: unknown): Promise<void> {
+    const previous = this.#sessionNewTail;
+    let release!: () => void;
+    this.#sessionNewTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    await previous;
+    try {
+      const response = this.#track(request.id, request.method, params);
+      this.#writeChild({ ...request, jsonrpc: "2.0", params });
+      await response;
+    } finally {
+      release();
+    }
   }
 
   async #handlePrompt(request: JsonRpcRequest, params: unknown): Promise<void> {
@@ -236,13 +257,14 @@ export class OfficialKernelProxy {
       if (params?.update?.sessionUpdate === "available_commands_update") {
         let cwd = sessionId ? this.#sessionCwds.get(sessionId) : undefined;
         if (!cwd) {
-          for (const pending of this.#pending.values()) {
-            if (pending.cwd) {
-              cwd = pending.cwd;
-              if (sessionId) {
-                this.#sessionCwds.set(sessionId, cwd);
-              }
-              break;
+          const pendingSessionNews = Array.from(this.#pending.values()).filter(
+            (pending): pending is PendingClientRequest & { cwd: string } =>
+              pending.method === SESSION_NEW_METHOD && pending.cwd !== undefined
+          );
+          if (pendingSessionNews.length === 1) {
+            cwd = pendingSessionNews[0].cwd;
+            if (sessionId) {
+              this.#sessionCwds.set(sessionId, cwd);
             }
           }
         }

--- a/ACP Connector/official-kernel/skill-commands.ts
+++ b/ACP Connector/official-kernel/skill-commands.ts
@@ -7,50 +7,112 @@ export interface AvailableCommand {
   description: string;
 }
 
-function parseFrontmatter(content: string): { name?: string; description?: string } {
-  if (!content.startsWith("---")) return {};
-  const endIdx = content.indexOf("\n---", 3);
-  if (endIdx === -1) return {};
+function parseYamlScalar(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return "";
 
-  const frontmatter = content.slice(3, endIdx).trim();
-  const lines = frontmatter.split("\n");
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed
+        .slice(1, -1)
+        .replace(/\\"/g, '"')
+        .replace(/\\\\/g, "\\")
+        .replace(/\\n/g, "\n")
+        .replace(/\\r/g, "\r")
+        .replace(/\\t/g, "\t");
+    }
+  }
+
+  if (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2) {
+    return trimmed.slice(1, -1).replace(/''/g, "'");
+  }
+
+  const commentIdx = trimmed.search(/\s+#/);
+  const withoutComment = commentIdx !== -1 ? trimmed.slice(0, commentIdx).trim() : trimmed;
+  return withoutComment;
+}
+
+function parseYamlBoolean(raw: string | undefined, defaultValue = true): boolean {
+  if (raw === undefined) return defaultValue;
+  const scalar = parseYamlScalar(raw).toLowerCase();
+  if (scalar === "false" || scalar === "no" || scalar === "off" || scalar === "0") {
+    return false;
+  }
+  if (scalar === "true" || scalar === "yes" || scalar === "on" || scalar === "1") {
+    return true;
+  }
+  return defaultValue;
+}
+
+export function parseFrontmatter(content: string): {
+  name?: string;
+  description?: string;
+  userInvocable?: boolean;
+} {
+  if (!content.startsWith("---")) return {};
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n(?:---|\.\.\.)(?:\r?\n|$)/);
+  if (!match) return {};
+
+  const frontmatter = match[1];
+  const lines = frontmatter.split(/\r?\n/);
   let name: string | undefined;
   let description: string | undefined;
+  let userInvocable: boolean | undefined;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    if (/^name:\s*/.test(line)) {
-      name = line.replace(/^name:\s*/, "").trim().replace(/^["']|["']$/g, "");
-    } else if (/^description:\s*/.test(line)) {
-      let desc = line.replace(/^description:\s*/, "").trim();
-      if (desc === ">-" || desc === ">" || desc === "|") {
-        const descLines: string[] = [];
+    const nameMatch = line.match(/^name:\s*(.*)$/);
+    if (nameMatch) {
+      name = parseYamlScalar(nameMatch[1]);
+      continue;
+    }
+
+    const invocableMatch = line.match(/^(?:user-invocable|user_invocable):\s*(.*)$/);
+    if (invocableMatch) {
+      userInvocable = parseYamlBoolean(invocableMatch[1], true);
+      continue;
+    }
+
+    const descMatch = line.match(/^description:\s*(.*)$/);
+    if (descMatch) {
+      const rest = descMatch[1].trim();
+      if (rest === ">" || rest === ">-" || rest === "|" || rest === "|-") {
+        const isFolded = rest.startsWith(">");
+        const blockLines: string[] = [];
         for (let j = i + 1; j < lines.length; j++) {
-          if (/^\s+/.test(lines[j])) {
-            descLines.push(lines[j].trim());
+          if (/^\s+/.test(lines[j]) || lines[j].trim().length === 0) {
+            blockLines.push(lines[j].trim());
             i = j;
           } else {
             break;
           }
         }
-        desc = descLines.join(" ");
+        if (isFolded) {
+          description = blockLines.filter((l) => l.length > 0).join(" ");
+        } else {
+          description = blockLines.join("\n").trim();
+        }
+      } else {
+        description = parseYamlScalar(rest);
       }
-      description = desc.replace(/^["']|["']$/g, "").trim();
+      continue;
     }
   }
 
-  return { name, description };
+  return { name, description, userInvocable };
 }
 
 export function resolveSkillRoots(cwd?: string): string[] {
-  const configuredRoots = new Set<string>();
+  const roots = new Set<string>();
   const home = homedir();
 
   const readSkillsJson = (filePath: string, baseDir: string): void => {
     if (!existsSync(filePath)) return;
     try {
       const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as {
-        entries?: Array<{ path: string }>;
+        entries?: Array<{ path?: string }>;
       };
       if (Array.isArray(parsed.entries)) {
         for (const entry of parsed.entries) {
@@ -65,7 +127,7 @@ export function resolveSkillRoots(cwd?: string): string[] {
               resolved = path.resolve(baseDir, trimmed);
             }
             if (existsSync(resolved)) {
-              configuredRoots.add(resolved);
+              roots.add(resolved);
             }
           }
         }
@@ -75,43 +137,42 @@ export function resolveSkillRoots(cwd?: string): string[] {
     }
   };
 
-  // 1. Workspace declared configs
+  // 1. Workspace declared configs in skills.json
   if (cwd && existsSync(cwd)) {
     readSkillsJson(path.join(cwd, ".agents/skills.json"), cwd);
     readSkillsJson(path.join(cwd, "skills.json"), cwd);
+    readSkillsJson(path.join(cwd, ".codex/skills.json"), cwd);
+    readSkillsJson(path.join(cwd, ".gemini/config/skills.json"), cwd);
   }
 
-  // 2. Global declared config (~/.gemini/config/skills.json)
-  readSkillsJson(path.join(home, ".gemini/config/skills.json"), home);
-
-  // If user configured any directories, use them
-  if (configuredRoots.size > 0) {
-    if (cwd && existsSync(cwd)) {
-      const wsDefault = path.join(cwd, ".agents/skills");
-      if (existsSync(wsDefault)) configuredRoots.add(wsDefault);
-    }
-    return Array.from(configuredRoots);
-  }
-
-  // 3. Fallback: Antigravity default skill locations
-  const defaultRoots = new Set<string>();
-
+  // 2. Workspace default skill directories
   if (cwd && existsSync(cwd)) {
-    const wsAgents = path.join(cwd, ".agents/skills");
-    const wsSkills = path.join(cwd, "skills");
-    if (existsSync(wsAgents)) defaultRoots.add(wsAgents);
-    if (existsSync(wsSkills)) defaultRoots.add(wsSkills);
+    const wsDefaults = [
+      path.join(cwd, ".agents/skills"),
+      path.join(cwd, ".codex/skills"),
+      path.join(cwd, "skills")
+    ];
+    for (const dir of wsDefaults) {
+      if (existsSync(dir)) roots.add(dir);
+    }
   }
 
+  // 3. Global declared configs in skills.json
+  readSkillsJson(path.join(home, ".gemini/config/skills.json"), home);
+  readSkillsJson(path.join(home, ".agents/skills.json"), home);
+  readSkillsJson(path.join(home, ".codex/skills.json"), home);
+
+  // 4. Global default skill directories
   const globalDefaults = [
     path.join(home, ".gemini/config/skills"),
-    path.join(home, ".agents/skills")
+    path.join(home, ".agents/skills"),
+    path.join(home, ".codex/skills")
   ];
   for (const dir of globalDefaults) {
-    if (existsSync(dir)) defaultRoots.add(dir);
+    if (existsSync(dir)) roots.add(dir);
   }
 
-  return Array.from(defaultRoots);
+  return Array.from(roots);
 }
 
 export function discoverSkillCommands(cwd?: string): AvailableCommand[] {
@@ -128,7 +189,10 @@ export function discoverSkillCommands(cwd?: string): AvailableCommand[] {
           if (existsSync(skillFile)) {
             try {
               const content = readFileSync(skillFile, "utf-8");
-              const { name, description } = parseFrontmatter(content);
+              const { name, description, userInvocable } = parseFrontmatter(content);
+              if (userInvocable === false) {
+                continue;
+              }
               const commandName = name && name.length > 0 ? name : entry.name;
               if (!commands.has(commandName)) {
                 commands.set(commandName, {
@@ -176,3 +240,4 @@ export function augmentAvailableCommands(
 
   return Array.from(result.values());
 }
+

--- a/ACP Connector/official-kernel/skill-commands.ts
+++ b/ACP Connector/official-kernel/skill-commands.ts
@@ -1,0 +1,152 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+export interface AvailableCommand {
+  name: string;
+  description: string;
+}
+
+function parseFrontmatter(content: string): { name?: string; description?: string } {
+  if (!content.startsWith("---")) return {};
+  const endIdx = content.indexOf("\n---", 3);
+  if (endIdx === -1) return {};
+
+  const frontmatter = content.slice(3, endIdx).trim();
+  const lines = frontmatter.split("\n");
+  let name: string | undefined;
+  let description: string | undefined;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^name:\s*/.test(line)) {
+      name = line.replace(/^name:\s*/, "").trim().replace(/^["']|["']$/g, "");
+    } else if (/^description:\s*/.test(line)) {
+      let desc = line.replace(/^description:\s*/, "").trim();
+      if (desc === ">-" || desc === ">" || desc === "|") {
+        const descLines: string[] = [];
+        for (let j = i + 1; j < lines.length; j++) {
+          if (/^\s+/.test(lines[j])) {
+            descLines.push(lines[j].trim());
+            i = j;
+          } else {
+            break;
+          }
+        }
+        desc = descLines.join(" ");
+      }
+      description = desc.replace(/^["']|["']$/g, "").trim();
+    }
+  }
+
+  return { name, description };
+}
+
+function resolveSkillRoots(cwd?: string): string[] {
+  const roots = new Set<string>();
+  const home = homedir();
+
+  // 1. Check ~/.gemini/config/skills.json
+  const skillsJsonPath = path.join(home, ".gemini/config/skills.json");
+  if (existsSync(skillsJsonPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(skillsJsonPath, "utf-8")) as {
+        entries?: Array<{ path: string }>;
+      };
+      if (Array.isArray(parsed.entries)) {
+        for (const entry of parsed.entries) {
+          if (entry.path) {
+            const resolved = entry.path.startsWith("~/")
+              ? path.join(home, entry.path.slice(2))
+              : entry.path;
+            if (existsSync(resolved)) roots.add(resolved);
+          }
+        }
+      }
+    } catch {
+      // Ignore JSON parse errors
+    }
+  }
+
+  // 2. Default global paths
+  const defaultGlobal = [
+    path.join(home, ".codex/skills"),
+    path.join(home, ".agents/skills")
+  ];
+  for (const dir of defaultGlobal) {
+    if (existsSync(dir)) roots.add(dir);
+  }
+
+  // 3. Workspace cwd paths if provided
+  if (cwd && existsSync(cwd)) {
+    const wsCodex = path.join(cwd, ".codex/skills");
+    const wsAgents = path.join(cwd, ".agents/skills");
+    if (existsSync(wsCodex)) roots.add(wsCodex);
+    if (existsSync(wsAgents)) roots.add(wsAgents);
+  }
+
+  return Array.from(roots);
+}
+
+export function discoverSkillCommands(cwd?: string): AvailableCommand[] {
+  const roots = resolveSkillRoots(cwd);
+  const commands = new Map<string, AvailableCommand>();
+
+  for (const root of roots) {
+    try {
+      const entries = readdirSync(root, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() || entry.isSymbolicLink()) {
+          const skillDir = path.join(root, entry.name);
+          const skillFile = path.join(skillDir, "SKILL.md");
+          if (existsSync(skillFile)) {
+            try {
+              const content = readFileSync(skillFile, "utf-8");
+              const { name, description } = parseFrontmatter(content);
+              const commandName = name && name.length > 0 ? name : entry.name;
+              if (!commands.has(commandName)) {
+                commands.set(commandName, {
+                  name: commandName,
+                  description:
+                    description && description.length > 0
+                      ? description
+                      : `Skill: ${commandName}`
+                });
+              }
+            } catch {
+              // Ignore file read errors
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore readdir errors
+    }
+  }
+
+  return Array.from(commands.values());
+}
+
+export function augmentAvailableCommands(
+  existingCommands: AvailableCommand[] | undefined,
+  cwd?: string
+): AvailableCommand[] {
+  const result = new Map<string, AvailableCommand>();
+
+  if (Array.isArray(existingCommands)) {
+    for (const cmd of existingCommands) {
+      if (cmd && typeof cmd.name === "string") {
+        result.set(cmd.name, cmd);
+      }
+    }
+  }
+
+  const skills = discoverSkillCommands(cwd);
+  for (const skill of skills) {
+    if (!result.has(skill.name)) {
+      result.set(skill.name, skill);
+    }
+  }
+
+  return Array.from(result.values());
+}

--- a/ACP Connector/official-kernel/skill-commands.ts
+++ b/ACP Connector/official-kernel/skill-commands.ts
@@ -42,50 +42,76 @@ function parseFrontmatter(content: string): { name?: string; description?: strin
   return { name, description };
 }
 
-function resolveSkillRoots(cwd?: string): string[] {
-  const roots = new Set<string>();
+export function resolveSkillRoots(cwd?: string): string[] {
+  const configuredRoots = new Set<string>();
   const home = homedir();
 
-  // 1. Check ~/.gemini/config/skills.json
-  const skillsJsonPath = path.join(home, ".gemini/config/skills.json");
-  if (existsSync(skillsJsonPath)) {
+  const readSkillsJson = (filePath: string, baseDir: string): void => {
+    if (!existsSync(filePath)) return;
     try {
-      const parsed = JSON.parse(readFileSync(skillsJsonPath, "utf-8")) as {
+      const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as {
         entries?: Array<{ path: string }>;
       };
       if (Array.isArray(parsed.entries)) {
         for (const entry of parsed.entries) {
-          if (entry.path) {
-            const resolved = entry.path.startsWith("~/")
-              ? path.join(home, entry.path.slice(2))
-              : entry.path;
-            if (existsSync(resolved)) roots.add(resolved);
+          if (entry && typeof entry.path === "string" && entry.path.trim().length > 0) {
+            const trimmed = entry.path.trim();
+            let resolved: string;
+            if (trimmed.startsWith("/")) {
+              resolved = trimmed;
+            } else if (trimmed.startsWith("~/")) {
+              resolved = path.join(home, trimmed.slice(2));
+            } else {
+              resolved = path.resolve(baseDir, trimmed);
+            }
+            if (existsSync(resolved)) {
+              configuredRoots.add(resolved);
+            }
           }
         }
       }
     } catch {
       // Ignore JSON parse errors
     }
+  };
+
+  // 1. Workspace declared configs
+  if (cwd && existsSync(cwd)) {
+    readSkillsJson(path.join(cwd, ".agents/skills.json"), cwd);
+    readSkillsJson(path.join(cwd, "skills.json"), cwd);
   }
 
-  // 2. Default global paths
-  const defaultGlobal = [
-    path.join(home, ".codex/skills"),
+  // 2. Global declared config (~/.gemini/config/skills.json)
+  readSkillsJson(path.join(home, ".gemini/config/skills.json"), home);
+
+  // If user configured any directories, use them
+  if (configuredRoots.size > 0) {
+    if (cwd && existsSync(cwd)) {
+      const wsDefault = path.join(cwd, ".agents/skills");
+      if (existsSync(wsDefault)) configuredRoots.add(wsDefault);
+    }
+    return Array.from(configuredRoots);
+  }
+
+  // 3. Fallback: Antigravity default skill locations
+  const defaultRoots = new Set<string>();
+
+  if (cwd && existsSync(cwd)) {
+    const wsAgents = path.join(cwd, ".agents/skills");
+    const wsSkills = path.join(cwd, "skills");
+    if (existsSync(wsAgents)) defaultRoots.add(wsAgents);
+    if (existsSync(wsSkills)) defaultRoots.add(wsSkills);
+  }
+
+  const globalDefaults = [
+    path.join(home, ".gemini/config/skills"),
     path.join(home, ".agents/skills")
   ];
-  for (const dir of defaultGlobal) {
-    if (existsSync(dir)) roots.add(dir);
+  for (const dir of globalDefaults) {
+    if (existsSync(dir)) defaultRoots.add(dir);
   }
 
-  // 3. Workspace cwd paths if provided
-  if (cwd && existsSync(cwd)) {
-    const wsCodex = path.join(cwd, ".codex/skills");
-    const wsAgents = path.join(cwd, ".agents/skills");
-    if (existsSync(wsCodex)) roots.add(wsCodex);
-    if (existsSync(wsAgents)) roots.add(wsAgents);
-  }
-
-  return Array.from(roots);
+  return Array.from(defaultRoots);
 }
 
 export function discoverSkillCommands(cwd?: string): AvailableCommand[] {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "node scripts/clean-dist.mjs && tsc && chmod +x 'dist/ACP Connector/main.js'",
+    "build": "node scripts/clean-dist.mjs && tsc",
     "typecheck": "tsc -p tsconfig.test.json",
     "test": "npm run typecheck && npm run build && vitest run",
     "validate:architecture": "node scripts/verify-import-boundaries.mjs",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "node scripts/clean-dist.mjs && tsc",
+    "build": "node scripts/clean-dist.mjs && tsc && chmod +x 'dist/ACP Connector/main.js'",
     "typecheck": "tsc -p tsconfig.test.json",
     "test": "npm run typecheck && npm run build && vitest run",
     "validate:architecture": "node scripts/verify-import-boundaries.mjs",

--- a/tests/helpers/fake-official-acp-agent.mjs
+++ b/tests/helpers/fake-official-acp-agent.mjs
@@ -33,12 +33,16 @@ rl.on("line", (line) => {
   }
 
   if (message.method === "session/new") {
+    const sessionId =
+      typeof message.params?.testSessionId === "string"
+        ? message.params.testSessionId
+        : "session-official-1";
     if (message.params?.emitAvailableCommands) {
       write({
         jsonrpc: "2.0",
         method: "session/update",
         params: {
-          sessionId: "session-official-1",
+          sessionId,
           update: {
             sessionUpdate: "available_commands_update",
             availableCommands: [
@@ -49,15 +53,22 @@ rl.on("line", (line) => {
         }
       });
     }
-    write({
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        sessionId: "session-official-1",
-        mcpServers: message.params?.mcpServers ?? [],
-        modeId: message.params?.modeId
-      }
-    });
+    const respond = () =>
+      write({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          sessionId,
+          mcpServers: message.params?.mcpServers ?? [],
+          modeId: message.params?.modeId
+        }
+      });
+    const delayMs = message.params?.testResponseDelayMs;
+    if (typeof delayMs === "number" && delayMs > 0) {
+      setTimeout(respond, delayMs);
+    } else {
+      respond();
+    }
     return;
   }
 

--- a/tests/helpers/fake-official-acp-agent.mjs
+++ b/tests/helpers/fake-official-acp-agent.mjs
@@ -33,6 +33,22 @@ rl.on("line", (line) => {
   }
 
   if (message.method === "session/new") {
+    if (message.params?.emitAvailableCommands) {
+      write({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "session-official-1",
+          update: {
+            sessionUpdate: "available_commands_update",
+            availableCommands: [
+              { name: "plan", description: "Plan mode" },
+              { name: "logout", description: "Log out" }
+            ]
+          }
+        }
+      });
+    }
     write({
       jsonrpc: "2.0",
       id: message.id,

--- a/tests/official-kernel.test.ts
+++ b/tests/official-kernel.test.ts
@@ -347,6 +347,76 @@ describe("official kernel proxy", () => {
     });
   });
 
+  it("keeps concurrent session/new workspace skills scoped to their sessions", async () => {
+    const wsA = tempDir("paseo-official-ws-a-");
+    const wsB = tempDir("paseo-official-ws-b-");
+    for (const [workspace, skillName] of [
+      [wsA, "a-only"],
+      [wsB, "b-only"]
+    ] as const) {
+      const skillDirectory = path.join(workspace, ".agents/skills", skillName);
+      mkdirSync(skillDirectory, { recursive: true });
+      writeFileSync(
+        path.join(skillDirectory, "SKILL.md"),
+        `---\nname: ${skillName}\ndescription: ${skillName}\n---\n`
+      );
+    }
+
+    await withProxy(async ({ send, waitFor }) => {
+      send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: 1 } });
+      await waitFor((message) => "id" in message && message.id === 1);
+
+      send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "session/new",
+        params: {
+          cwd: wsA,
+          emitAvailableCommands: true,
+          testSessionId: "session-a",
+          testResponseDelayMs: 75
+        }
+      });
+      send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "session/new",
+        params: {
+          cwd: wsB,
+          emitAvailableCommands: true,
+          testSessionId: "session-b"
+        }
+      });
+
+      const commandsFor = async (sessionId: string) => {
+        const update = (await waitFor(
+          (message) =>
+            "method" in message &&
+            message.method === "session/update" &&
+            (message.params as { sessionId?: string } | undefined)?.sessionId === sessionId &&
+            (message.params as { update?: { sessionUpdate?: string } } | undefined)?.update
+              ?.sessionUpdate === "available_commands_update"
+        )) as {
+          params?: {
+            update?: {
+              availableCommands?: Array<{ name: string; description: string }>;
+            };
+          };
+        };
+        return update.params?.update?.availableCommands ?? [];
+      };
+
+      const commandsA = await commandsFor("session-a");
+      const commandsB = await commandsFor("session-b");
+      expect(commandsA.some((command) => command.name === "a-only")).toBe(true);
+      expect(commandsA.some((command) => command.name === "b-only")).toBe(false);
+      expect(commandsB.some((command) => command.name === "b-only")).toBe(true);
+      expect(commandsB.some((command) => command.name === "a-only")).toBe(false);
+      await waitFor((message) => "id" in message && message.id === 2);
+      await waitFor((message) => "id" in message && message.id === 3);
+    });
+  });
+
   it("lets the packaged CLI talk to the official kernel through the product proxy", async () => {
     chmodSync(fakeOfficialAgent, 0o755);
     const child = spawn(process.execPath, [builtCli], {

--- a/tests/official-kernel.test.ts
+++ b/tests/official-kernel.test.ts
@@ -292,6 +292,61 @@ describe("official kernel proxy", () => {
     );
   });
 
+  it("augments available commands with workspace skills and excludes user-invocable: false", async () => {
+    const ws = tempDir("paseo-official-ws-skills-");
+    const skillA = path.join(ws, ".agents/skills/ws-skill");
+    mkdirSync(skillA, { recursive: true });
+    writeFileSync(
+      path.join(skillA, "SKILL.md"),
+      `---\nname: ws-skill\ndescription: "Workspace skill description"\n---\n`
+    );
+
+    const skillHidden = path.join(ws, ".agents/skills/hidden-skill");
+    mkdirSync(skillHidden, { recursive: true });
+    writeFileSync(
+      path.join(skillHidden, "SKILL.md"),
+      `---\nname: hidden-skill\ndescription: "Hidden skill"\nuser-invocable: false\n---\n`
+    );
+
+    await withProxy(async ({ send, waitFor }) => {
+      send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: 1 } });
+      await waitFor((message) => "id" in message && message.id === 1);
+
+      send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "session/new",
+        params: {
+          cwd: ws,
+          emitAvailableCommands: true
+        }
+      });
+      await waitFor((message) => "id" in message && message.id === 2);
+
+      const update = (await waitFor(
+        (message) =>
+          "method" in message &&
+          message.method === "session/update" &&
+          (message.params as { update?: { sessionUpdate?: string } } | undefined)?.update
+            ?.sessionUpdate === "available_commands_update"
+      )) as {
+        params?: {
+          update?: {
+            availableCommands?: Array<{ name: string; description: string }>;
+          };
+        };
+      };
+
+      const commands = update.params?.update?.availableCommands ?? [];
+      expect(commands.find((c) => c.name === "plan")?.description).toBe("Plan mode");
+      expect(commands.find((c) => c.name === "logout")?.description).toBe("Log out");
+      expect(commands.find((c) => c.name === "ws-skill")?.description).toBe(
+        "Workspace skill description"
+      );
+      expect(commands.find((c) => c.name === "hidden-skill")).toBeUndefined();
+    });
+  });
+
   it("lets the packaged CLI talk to the official kernel through the product proxy", async () => {
     chmodSync(fakeOfficialAgent, 0o755);
     const child = spawn(process.execPath, [builtCli], {

--- a/tests/skill-commands.test.ts
+++ b/tests/skill-commands.test.ts
@@ -4,7 +4,8 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   augmentAvailableCommands,
-  discoverSkillCommands
+  discoverSkillCommands,
+  resolveSkillRoots
 } from "../ACP Connector/official-kernel/skill-commands.js";
 
 const tempDirs: string[] = [];
@@ -22,32 +23,62 @@ function tempDir(prefix: string): string {
 }
 
 describe("Skill Commands Discovery", () => {
-  it("discovers skills from workspace skills directory", () => {
-    const ws = tempDir("ws-skills-");
-    const codexSkills = path.join(ws, ".codex/skills");
-    const skillA = path.join(codexSkills, "my-skill");
+  it("discovers skills from configured skills.json", () => {
+    const ws = tempDir("ws-custom-");
+    const customSkillDir = tempDir("custom-skill-target-");
+    const skillA = path.join(customSkillDir, "custom-declared-skill");
     mkdirSync(skillA, { recursive: true });
     writeFileSync(
       path.join(skillA, "SKILL.md"),
       `---
-name: my-skill
-description: Custom test skill
+name: custom-declared-skill
+description: Declared from custom skills.json
 ---
-# My Skill
+# Declared Skill
+`
+    );
+
+    // Create workspace skills.json pointing to customSkillDir
+    mkdirSync(path.join(ws, ".agents"), { recursive: true });
+    writeFileSync(
+      path.join(ws, ".agents/skills.json"),
+      JSON.stringify({
+        entries: [{ path: customSkillDir }]
+      })
+    );
+
+    const roots = resolveSkillRoots(ws);
+    expect(roots).toContain(customSkillDir);
+
+    const commands = discoverSkillCommands(ws);
+    const found = commands.find((c) => c.name === "custom-declared-skill");
+    expect(found).toBeDefined();
+    expect(found?.description).toBe("Declared from custom skills.json");
+  });
+
+  it("falls back to default Antigravity skill paths when unconfigured", () => {
+    const ws = tempDir("ws-default-");
+    const defaultWsSkills = path.join(ws, ".agents/skills/default-skill");
+    mkdirSync(defaultWsSkills, { recursive: true });
+    writeFileSync(
+      path.join(defaultWsSkills, "SKILL.md"),
+      `---
+name: default-skill
+description: Default location skill
+---
 `
     );
 
     const commands = discoverSkillCommands(ws);
-    const found = commands.find((c) => c.name === "my-skill");
+    const found = commands.find((c) => c.name === "default-skill");
     expect(found).toBeDefined();
-    expect(found?.description).toBe("Custom test skill");
+    expect(found?.description).toBe("Default location skill");
   });
 
   it("augments existing available commands without duplicating", () => {
-    const ws = tempDir("ws-skills-");
-    const codexSkills = path.join(ws, ".codex/skills");
-    const skillA = path.join(codexSkills, "plan");
-    const skillB = path.join(codexSkills, "extra-skill");
+    const ws = tempDir("ws-merge-");
+    const skillA = path.join(ws, ".agents/skills/plan");
+    const skillB = path.join(ws, ".agents/skills/extra-skill");
     mkdirSync(skillA, { recursive: true });
     mkdirSync(skillB, { recursive: true });
     writeFileSync(

--- a/tests/skill-commands.test.ts
+++ b/tests/skill-commands.test.ts
@@ -1,0 +1,72 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  augmentAvailableCommands,
+  discoverSkillCommands
+} from "../ACP Connector/official-kernel/skill-commands.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const directory of tempDirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function tempDir(prefix: string): string {
+  const directory = mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(directory);
+  return directory;
+}
+
+describe("Skill Commands Discovery", () => {
+  it("discovers skills from workspace skills directory", () => {
+    const ws = tempDir("ws-skills-");
+    const codexSkills = path.join(ws, ".codex/skills");
+    const skillA = path.join(codexSkills, "my-skill");
+    mkdirSync(skillA, { recursive: true });
+    writeFileSync(
+      path.join(skillA, "SKILL.md"),
+      `---
+name: my-skill
+description: Custom test skill
+---
+# My Skill
+`
+    );
+
+    const commands = discoverSkillCommands(ws);
+    const found = commands.find((c) => c.name === "my-skill");
+    expect(found).toBeDefined();
+    expect(found?.description).toBe("Custom test skill");
+  });
+
+  it("augments existing available commands without duplicating", () => {
+    const ws = tempDir("ws-skills-");
+    const codexSkills = path.join(ws, ".codex/skills");
+    const skillA = path.join(codexSkills, "plan");
+    const skillB = path.join(codexSkills, "extra-skill");
+    mkdirSync(skillA, { recursive: true });
+    mkdirSync(skillB, { recursive: true });
+    writeFileSync(
+      path.join(skillA, "SKILL.md"),
+      `---\nname: plan\ndescription: Custom plan override\n---\n`
+    );
+    writeFileSync(
+      path.join(skillB, "SKILL.md"),
+      `---\nname: extra-skill\ndescription: Extra skill description\n---\n`
+    );
+
+    const initial = [{ name: "plan", description: "Official plan" }];
+    const augmented = augmentAvailableCommands(initial, ws);
+
+    // Initial commands are preserved and not overridden
+    expect(augmented.find((c) => c.name === "plan")?.description).toBe("Official plan");
+    // Extra skills are appended
+    expect(augmented.find((c) => c.name === "extra-skill")?.description).toBe(
+      "Extra skill description"
+    );
+  });
+});

--- a/tests/skill-commands.test.ts
+++ b/tests/skill-commands.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   augmentAvailableCommands,
   discoverSkillCommands,
+  parseFrontmatter,
   resolveSkillRoots
 } from "../ACP Connector/official-kernel/skill-commands.js";
 
@@ -21,6 +22,81 @@ function tempDir(prefix: string): string {
   tempDirs.push(directory);
   return directory;
 }
+
+describe("Frontmatter Parsing", () => {
+  it("parses unquoted, double-quoted, and single-quoted fields cleanly without escape artifacts", () => {
+    const content = `---
+name: "my-skill"
+description: "\\"Review this PR\\""
+---
+# Skill body`;
+    const parsed = parseFrontmatter(content);
+    expect(parsed.name).toBe("my-skill");
+    expect(parsed.description).toBe('"Review this PR"');
+  });
+
+  it("parses single-quoted strings and escaped single quotes", () => {
+    const content = `---
+name: 'quote-skill'
+description: 'Don''t miss this'
+---`;
+    const parsed = parseFrontmatter(content);
+    expect(parsed.name).toBe("quote-skill");
+    expect(parsed.description).toBe("Don't miss this");
+  });
+
+  it("parses multi-line folded and literal descriptions", () => {
+    const folded = `---
+name: folded-skill
+description: >-
+  First line of folded description
+  second line of folded description.
+---`;
+    expect(parseFrontmatter(folded).description).toBe(
+      "First line of folded description second line of folded description."
+    );
+
+    const literal = `---
+name: literal-skill
+description: |
+  Line 1
+  Line 2
+---`;
+    expect(parseFrontmatter(literal).description).toBe("Line 1\nLine 2");
+  });
+
+  it("parses user-invocable flag in boolean and string forms", () => {
+    const disabledBool = `---
+name: skill-1
+user-invocable: false
+---`;
+    expect(parseFrontmatter(disabledBool).userInvocable).toBe(false);
+
+    const disabledUnderscore = `---
+name: skill-2
+user_invocable: false
+---`;
+    expect(parseFrontmatter(disabledUnderscore).userInvocable).toBe(false);
+
+    const disabledStr = `---
+name: skill-3
+user-invocable: "false"
+---`;
+    expect(parseFrontmatter(disabledStr).userInvocable).toBe(false);
+
+    const enabled = `---
+name: skill-4
+user-invocable: true
+---`;
+    expect(parseFrontmatter(enabled).userInvocable).toBe(true);
+
+    const defaultInvocable = `---
+name: skill-5
+description: default
+---`;
+    expect(parseFrontmatter(defaultInvocable).userInvocable).toBeUndefined();
+  });
+});
 
 describe("Skill Commands Discovery", () => {
   it("discovers skills from configured skills.json", () => {
@@ -54,6 +130,56 @@ description: Declared from custom skills.json
     const found = commands.find((c) => c.name === "custom-declared-skill");
     expect(found).toBeDefined();
     expect(found?.description).toBe("Declared from custom skills.json");
+  });
+
+  it("discovers skills from .codex/skills in workspace", () => {
+    const ws = tempDir("ws-codex-");
+    const codexSkill = path.join(ws, ".codex/skills/codex-probe");
+    mkdirSync(codexSkill, { recursive: true });
+    writeFileSync(
+      path.join(codexSkill, "SKILL.md"),
+      `---
+name: codex-probe
+description: "Codex skill description"
+---
+`
+    );
+
+    const roots = resolveSkillRoots(ws);
+    expect(roots).toContain(path.join(ws, ".codex/skills"));
+
+    const commands = discoverSkillCommands(ws);
+    const found = commands.find((c) => c.name === "codex-probe");
+    expect(found).toBeDefined();
+    expect(found?.description).toBe("Codex skill description");
+  });
+
+  it("excludes skills with user-invocable: false", () => {
+    const ws = tempDir("ws-invocable-");
+    const visibleSkill = path.join(ws, ".agents/skills/visible-skill");
+    const hiddenSkill = path.join(ws, ".agents/skills/shadcn");
+    mkdirSync(visibleSkill, { recursive: true });
+    mkdirSync(hiddenSkill, { recursive: true });
+
+    writeFileSync(
+      path.join(visibleSkill, "SKILL.md"),
+      `---
+name: visible-skill
+description: Available to user
+---`
+    );
+    writeFileSync(
+      path.join(hiddenSkill, "SKILL.md"),
+      `---
+name: shadcn
+description: Add components
+user-invocable: false
+---`
+    );
+
+    const commands = discoverSkillCommands(ws);
+    expect(commands.find((c) => c.name === "visible-skill")).toBeDefined();
+    expect(commands.find((c) => c.name === "shadcn")).toBeUndefined();
   });
 
   it("falls back to default Antigravity skill paths when unconfigured", () => {
@@ -101,3 +227,4 @@ description: Default location skill
     );
   });
 });
+


### PR DESCRIPTION
### Summary
This PR automatically discovers local and workspace skills (from `~/.gemini/config/skills.json`, `~/.codex/skills`, `~/.agents/skills`, or workspace `.agents/skills`) and augments the ACP `available_commands_update` notification with these skills.

### Motivation
When using Antigravity ACP in Paseo (or any standard ACP client), the official `agy_acp_server` only reports `plan` and `logout` in `availableCommands`. Consequently, typing `/` in the Paseo input box does not provide hints or autocompletion for installed skills.

### Changes
- Added `ACP Connector/official-kernel/skill-commands.ts` to parse `SKILL.md` frontmatter and discover available skills.
- Updated `OfficialKernelProxy.#onChildMessage` in `proxy.ts` to intercept `available_commands_update` and augment `availableCommands` with local skills while preserving native commands.
- Added comprehensive unit tests in `tests/skill-commands.test.ts`.