### PR TITLE
fix: show OAuth URL promptly during official login

### DIFF
--- a/ACP Connector/official-kernel/login.ts
+++ b/ACP Connector/official-kernel/login.ts
@@ -1,3 +1,6 @@
+import { get } from "node:http";
+import { createInterface } from "node:readline/promises";
+import type { Readable } from "node:stream";
 import {
   isJsonRpcFailure,
   isJsonRpcSuccess,
@@ -11,7 +14,8 @@ const AUTHENTICATE_TIMEOUT_MS = 10 * 60_000;
 
 export async function runOfficialLogin(
   environment: NodeJS.ProcessEnv = process.env,
-  version = "0.0.0"
+  version = "0.0.0",
+  input: Readable = process.stdin
 ): Promise<number> {
   process.stderr.write(
     "Starting official Antigravity ACP login (authenticate methodId=oauth-personal).\n"
@@ -21,6 +25,9 @@ export async function runOfficialLogin(
   const child = spawnOfficialKernel({ ...environment, PYTHONUNBUFFERED: "1" });
   const pending = new Map<JsonRpcId, (message: JsonRpcMessage) => void>();
   let nextId = 1;
+  let authenticationStarted = false;
+  let promptCallback: Promise<void> | undefined;
+  let rejectLogin: ((reason?: unknown) => void) | undefined;
 
   const parse = createNdjsonParser(
     (message) => {
@@ -35,7 +42,14 @@ export async function runOfficialLogin(
         settle?.(message);
       }
     },
-    (line) => process.stderr.write(`${line}\n`)
+    (line) => {
+      process.stderr.write(`${formatLoginOutput(line)}\n`);
+      if (authenticationStarted && !promptCallback && extractUrl(line)) {
+        promptCallback = promptForCallbackUrl(input)
+          .then(deliverOAuthCallback)
+          .catch((error) => rejectLogin?.(error));
+      }
+    }
   );
   child.stdout.on("data", parse);
 
@@ -63,7 +77,13 @@ export async function runOfficialLogin(
     if (isJsonRpcFailure(initialized)) {
       throw new Error(initialized.error.message);
     }
-    const authenticated = await request("authenticate", { methodId: "oauth-personal" });
+    authenticationStarted = true;
+    const authenticated = await Promise.race([
+      request("authenticate", { methodId: "oauth-personal" }),
+      new Promise<never>((_, reject) => {
+        rejectLogin = reject;
+      })
+    ]);
     if (isJsonRpcFailure(authenticated)) {
       throw new Error(authenticated.error.message);
     }
@@ -81,6 +101,57 @@ export async function runOfficialLogin(
       child.kill("SIGTERM");
     }
   }
+}
+
+function extractUrl(line: string): string | undefined {
+  return line.match(/https?:\/\/\S+/)?.[0];
+}
+
+function formatLoginOutput(line: string): string {
+  const url = extractUrl(line);
+  if (!url || !line.startsWith("Open the following link to authenticate the ACP server:")) {
+    return line;
+  }
+  return `${line.slice(0, line.indexOf(url)).trimEnd()}\n\n${url}\n`;
+}
+
+async function promptForCallbackUrl(input: Readable): Promise<string> {
+  const readline = createInterface({ input, output: process.stderr });
+  try {
+    const callbackUrl = (await readline.question("\nPaste the OAuth callback URL to finish login: ")).trim();
+    if (callbackUrl.length === 0) throw new Error("OAuth callback URL is required");
+    return callbackUrl;
+  } finally {
+    readline.close();
+  }
+}
+
+function deliverOAuthCallback(callbackUrl: string): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(callbackUrl);
+  } catch {
+    return Promise.reject(new Error("OAuth callback URL is invalid"));
+  }
+  if (url.protocol !== "http:" || !isLoopbackHost(url.hostname)) {
+    return Promise.reject(new Error("OAuth callback URL must use a local HTTP address"));
+  }
+  return new Promise((resolve, reject) => {
+    const request = get(url, (response) => {
+      response.resume();
+      if ((response.statusCode ?? 500) >= 400) {
+        reject(new Error(`OAuth callback returned HTTP ${response.statusCode}`));
+      } else {
+        resolve();
+      }
+    });
+    request.setTimeout(10_000, () => request.destroy(new Error("OAuth callback timed out")));
+    request.once("error", reject);
+  });
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]";
 }
 
 function summarizeAuthUpdate(method: string, params: unknown): string {

--- a/ACP Connector/official-kernel/login.ts
+++ b/ACP Connector/official-kernel/login.ts
@@ -16,22 +16,27 @@ export async function runOfficialLogin(
   process.stderr.write(
     "Starting official Antigravity ACP login (authenticate methodId=oauth-personal).\n"
   );
-  const child = spawnOfficialKernel(environment);
+  // The official kernel prints the OAuth URL as ordinary stdout text. Its
+  // stdout is a pipe here, so force Python to flush that prompt immediately.
+  const child = spawnOfficialKernel({ ...environment, PYTHONUNBUFFERED: "1" });
   const pending = new Map<JsonRpcId, (message: JsonRpcMessage) => void>();
   let nextId = 1;
 
-  const parse = createNdjsonParser((message) => {
-    if ("method" in message && !("id" in message)) {
-      const params = "params" in message ? message.params : undefined;
-      process.stderr.write(`${summarizeAuthUpdate(message.method, params)}\n`);
-      return;
-    }
-    if ("id" in message && pending.has(message.id)) {
-      const settle = pending.get(message.id);
-      pending.delete(message.id);
-      settle?.(message);
-    }
-  });
+  const parse = createNdjsonParser(
+    (message) => {
+      if ("method" in message && !("id" in message)) {
+        const params = "params" in message ? message.params : undefined;
+        process.stderr.write(`${summarizeAuthUpdate(message.method, params)}\n`);
+        return;
+      }
+      if ("id" in message && pending.has(message.id)) {
+        const settle = pending.get(message.id);
+        pending.delete(message.id);
+        settle?.(message);
+      }
+    },
+    (line) => process.stderr.write(`${line}\n`)
+  );
   child.stdout.on("data", parse);
 
   const request = (method: string, params: unknown): Promise<JsonRpcMessage> => {

--- a/tests/official-kernel.test.ts
+++ b/tests/official-kernel.test.ts
@@ -90,9 +90,11 @@ describe("official kernel login", () => {
   it("forwards a pasted OAuth callback URL after the kernel prints its authorization URL", async () => {
     const directory = tempDir("paseo-official-login-");
     const kernel = path.join(directory, "fake-login-kernel.mjs");
+    const callbackSignal = path.join(directory, "callback-received");
     let callbackReceived = false;
     const callbackServer = createServer((_request, response) => {
       callbackReceived = true;
+      writeFileSync(callbackSignal, "received");
       response.end("OAuth callback accepted");
     });
     await new Promise<void>((resolve) => callbackServer.listen(0, "127.0.0.1", resolve));
@@ -101,6 +103,7 @@ describe("official kernel login", () => {
     writeFileSync(
       kernel,
       `#!/usr/bin/env node
+import { existsSync } from "node:fs";
 import readline from "node:readline";
 const rl = readline.createInterface({ input: process.stdin });
 let authenticateId;
@@ -111,7 +114,11 @@ rl.on("line", (line) => {
   } else if (message.method === "authenticate") {
     authenticateId = message.id;
     process.stdout.write("https://accounts.example/authorize\\n");
-    setTimeout(() => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: authenticateId, result: {} }) + "\\n"), 50);
+    const waitForCallback = setInterval(() => {
+      if (!existsSync(process.env.TEST_CALLBACK_SIGNAL)) return;
+      clearInterval(waitForCallback);
+      process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: authenticateId, result: {} }) + "\\n");
+    }, 10);
   }
 });
 `
@@ -122,7 +129,11 @@ rl.on("line", (line) => {
 
     try {
       await expect(
-        runOfficialLogin({ PASEO_AGY_ACP_OFFICIAL_BIN: kernel }, "test", input)
+        runOfficialLogin(
+          { ...process.env, PASEO_AGY_ACP_OFFICIAL_BIN: kernel, TEST_CALLBACK_SIGNAL: callbackSignal },
+          "test",
+          input
+        )
       ).resolves.toBe(0);
       expect(callbackReceived).toBe(true);
     } finally {

--- a/tests/official-kernel.test.ts
+++ b/tests/official-kernel.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -24,6 +25,7 @@ import { rewriteMcpServers } from "../ACP Connector/official-kernel/mcp-rewrite.
 import { mapToOfficialModeId, rewriteModeFields } from "../ACP Connector/official-kernel/mode-map.js";
 import { createNdjsonParser, encodeNdjson } from "../ACP Connector/official-kernel/ndjson.js";
 import { OfficialKernelProxy } from "../ACP Connector/official-kernel/proxy.js";
+import { runOfficialLogin } from "../ACP Connector/official-kernel/login.js";
 import { officialSpawnArgs, resolveOfficialBinary } from "../ACP Connector/official-kernel/spawn.js";
 import { PASEO_DAEMON_CONTEXT_OPEN } from "../ACP Connector/acp/session/paseo-context.js";
 import type { JsonRpcMessage } from "../ACP Connector/official-kernel/json-rpc.js";
@@ -81,6 +83,51 @@ describe("official kernel selection", () => {
     expect(officialSpawnArgs("/tmp/agy_acp_server.par")).toEqual(["--uid="]);
     expect(officialSpawnArgs(fakeOfficialAgent)).toEqual([]);
     expect(resolveOfficialBinary({ PASEO_AGY_ACP_OFFICIAL_BIN: fakeOfficialAgent })).toBe(fakeOfficialAgent);
+  });
+});
+
+describe("official kernel login", () => {
+  it("forwards a pasted OAuth callback URL after the kernel prints its authorization URL", async () => {
+    const directory = tempDir("paseo-official-login-");
+    const kernel = path.join(directory, "fake-login-kernel.mjs");
+    let callbackReceived = false;
+    const callbackServer = createServer((_request, response) => {
+      callbackReceived = true;
+      response.end("OAuth callback accepted");
+    });
+    await new Promise<void>((resolve) => callbackServer.listen(0, "127.0.0.1", resolve));
+    const address = callbackServer.address();
+    if (!address || typeof address === "string") throw new Error("callback test server did not listen");
+    writeFileSync(
+      kernel,
+      `#!/usr/bin/env node
+import readline from "node:readline";
+const rl = readline.createInterface({ input: process.stdin });
+let authenticateId;
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: {} }) + "\\n");
+  } else if (message.method === "authenticate") {
+    authenticateId = message.id;
+    process.stdout.write("https://accounts.example/authorize\\n");
+    setTimeout(() => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: authenticateId, result: {} }) + "\\n"), 50);
+  }
+});
+`
+    );
+    chmodSync(kernel, 0o755);
+    const input = new PassThrough();
+    input.end(`http://127.0.0.1:${address.port}/?code=example\n`);
+
+    try {
+      await expect(
+        runOfficialLogin({ PASEO_AGY_ACP_OFFICIAL_BIN: kernel }, "test", input)
+      ).resolves.toBe(0);
+      expect(callbackReceived).toBe(true);
+    } finally {
+      await new Promise<void>((resolve) => callbackServer.close(() => resolve()));
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- display the official OAuth authorization URL on its own line for easy copying
- prompt for the browser callback URL and deliver it to the official kernel local callback listener
- restrict callback delivery to local HTTP loopback addresses
- add coverage for the pasted-callback login flow

## Validation

- npm test (37 files passed; 217 tests passed, 1 skipped)

The normal ACP proxy path is unchanged.